### PR TITLE
Support C Plus Plus

### DIFF
--- a/artemis/examples/hello_world_uart/gcc/Makefile
+++ b/artemis/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artemis/examples/hello_world_uart/gcc/Makefile
+++ b/artemis/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artemis/examples/hello_world_uart/gcc/Makefile
+++ b/artemis/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artemis/examples/hello_world_uart_cpp/README.txt
+++ b/artemis/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/artemis/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/artemis/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/artemis_thing_plus/examples/blinky/gcc/Makefile
+++ b/artemis_thing_plus/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artemis_thing_plus/examples/blinky/gcc/Makefile
+++ b/artemis_thing_plus/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artemis_thing_plus/examples/blinky/gcc/Makefile
+++ b/artemis_thing_plus/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
+++ b/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
+++ b/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
+++ b/artemis_thing_plus/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
+++ b/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
+++ b/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
+++ b/artemis_thing_plus/examples/pdm_fft/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artemis_thing_plus/hello_world_uart_cpp/README.txt
+++ b/artemis_thing_plus/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/artemis_thing_plus/hello_world_uart_cpp/gcc/Makefile
+++ b/artemis_thing_plus/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/artmbed/examples/blinky/gcc/Makefile
+++ b/artmbed/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artmbed/examples/blinky/gcc/Makefile
+++ b/artmbed/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artmbed/examples/blinky/gcc/Makefile
+++ b/artmbed/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artmbed/examples/hello_world_uart/gcc/Makefile
+++ b/artmbed/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/artmbed/examples/hello_world_uart/gcc/Makefile
+++ b/artmbed/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/artmbed/examples/hello_world_uart/gcc/Makefile
+++ b/artmbed/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/artmbed/examples/hello_world_uart_cpp/README.txt
+++ b/artmbed/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/artmbed/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/artmbed/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -49,7 +49,9 @@
 //
 //*****************************************************************************
 
-extern "C" { #include "am_mcu_apollo.h" } // extern "C" is required because Release 2.2.0 of the AmbiqSuite SDK still has some HAL headers without this CPP guard built in
+extern "C" {                    // extern "C" is required because Release 2.2.0 of the 
+    #include "am_mcu_apollo.h"  // AmbiqSuite SDK still has some HAL headers without 
+}                               // this CPP guard built in
 #include "am_bsp.h"
 #include "am_util.h"
 

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -94,7 +94,7 @@ uint8_t g_pui8RxBuffer[2];
 // UART configuration.
 //
 //*****************************************************************************
-const am_hal_uart_config_t g_sUartConfig = {0};
+am_hal_uart_config_t g_sUartConfig = {0};
 
 //*****************************************************************************
 //

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -69,7 +69,7 @@ public:
     CPPPrinter( uint8_t _value ) : value(_value) {};
 
     void printValue( void ){
-        am_util_stdio_printf("I am a CPPPrinter and my value is %d\n", value);
+        am_util_stdio_printf("I am a CPPPrinter and my value is %d\n\n", value);
     }
 };
 

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -1,0 +1,318 @@
+//*****************************************************************************
+//
+//! @file hello_world_uart.cpp
+//!
+//! @brief A simple "Hello World" example using the UART peripheral.
+//!
+//! Purpose: This example prints a "Hello World" message with some device info
+//! over UART at 115200 baud. To see the output of this program, run AMFlash,
+//! and configure the console for UART. The example sleeps after it is done
+//! printing.
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2019, Ambiq Micro
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision v2.2.0-7-g63f7c2ba1 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#include "am_mcu_apollo.h"
+#include "am_bsp.h"
+#include "am_util.h"
+
+//*****************************************************************************
+//
+// UART handle.
+//
+//*****************************************************************************
+void *phUART;
+
+#define CHECK_ERRORS(x)                                                       \
+    if ((x) != AM_HAL_STATUS_SUCCESS)                                         \
+    {                                                                         \
+        error_handler(x);                                                     \
+    }
+
+volatile uint32_t ui32LastError;
+
+//*****************************************************************************
+//
+// Catch HAL errors.
+//
+//*****************************************************************************
+void
+error_handler(uint32_t ui32ErrorStatus)
+{
+    ui32LastError = ui32ErrorStatus;
+
+    while (1);
+}
+
+//*****************************************************************************
+//
+// UART buffers.
+//
+//*****************************************************************************
+uint8_t g_pui8TxBuffer[256];
+uint8_t g_pui8RxBuffer[2];
+
+//*****************************************************************************
+//
+// UART configuration.
+//
+//*****************************************************************************
+const am_hal_uart_config_t g_sUartConfig = {0};
+
+//*****************************************************************************
+//
+// UART0 interrupt handler.
+//
+//*****************************************************************************
+extern "C" void am_uart_isr(void)
+{
+    //
+    // Service the FIFOs as necessary, and clear the interrupts.
+    //
+    uint32_t ui32Status, ui32Idle;
+    am_hal_uart_interrupt_status_get(phUART, &ui32Status, true);
+    am_hal_uart_interrupt_clear(phUART, ui32Status);
+    am_hal_uart_interrupt_service(phUART, ui32Status, &ui32Idle);
+}
+
+//*****************************************************************************
+//
+// UART print string
+//
+//*****************************************************************************
+void
+uart_print(char *pcStr)
+{
+    uint32_t ui32StrLen = 0;
+    uint32_t ui32BytesWritten = 0;
+
+    //
+    // Measure the length of the string.
+    //
+    while (pcStr[ui32StrLen] != 0)
+    {
+        ui32StrLen++;
+    }
+
+    //
+    // Print the string via the UART.
+    //
+    const am_hal_uart_transfer_t sUartWrite =
+    {
+        .ui32Direction = AM_HAL_UART_WRITE,
+        .pui8Data = (uint8_t *) pcStr,
+        .ui32NumBytes = ui32StrLen,
+        .ui32TimeoutMs = 0,
+        .pui32BytesTransferred = &ui32BytesWritten,
+    };
+
+    CHECK_ERRORS(am_hal_uart_transfer(phUART, &sUartWrite));
+
+    if (ui32BytesWritten != ui32StrLen)
+    {
+        //
+        // Couldn't send the whole string!!
+        //
+        while(1);
+    }
+}
+
+
+//*****************************************************************************
+//
+// Main
+//
+//*****************************************************************************
+extern "C" int main(void)
+{
+    am_util_id_t sIdDevice;
+    uint32_t ui32StrBuf;
+
+    // Initialize Uart Configuration Structure
+    g_sUartConfig.ui32BaudRate = 115200;
+    g_sUartConfig.ui32DataBits = AM_HAL_UART_DATA_BITS_8;
+    g_sUartConfig.ui32Parity = AM_HAL_UART_PARITY_NONE;
+    g_sUartConfig.ui32StopBits = AM_HAL_UART_ONE_STOP_BIT;
+    g_sUartConfig.ui32FlowControl = AM_HAL_UART_FLOW_CTRL_NONE;
+    g_sUartConfig.ui32FifoLevels = (AM_HAL_UART_TX_FIFO_1_2 | AM_HAL_UART_RX_FIFO_1_2);
+    g_sUartConfig.pui8TxBuffer = g_pui8TxBuffer;
+    g_sUartConfig.ui32TxBufferSize = sizeof(g_pui8TxBuffer);
+    g_sUartConfig.pui8RxBuffer = g_pui8RxBuffer;
+    g_sUartConfig.ui32RxBufferSize = sizeof(g_pui8RxBuffer);
+
+    //
+    // Set the clock frequency.
+    //
+    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+
+    //
+    // Set the default cache configuration
+    //
+    am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
+    am_hal_cachectrl_enable();
+
+    //
+    // Configure the board for low power operation.
+    //
+    am_bsp_low_power_init();
+
+    //
+    // Initialize the printf interface for UART output.
+    //
+    CHECK_ERRORS(am_hal_uart_initialize(0, &phUART));
+    CHECK_ERRORS(am_hal_uart_power_control(phUART, AM_HAL_SYSCTRL_WAKE, false));
+    CHECK_ERRORS(am_hal_uart_configure(phUART, &g_sUartConfig));
+
+    //
+    // Enable the UART pins.
+    //
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_BSP_GPIO_COM_UART_TX);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_BSP_GPIO_COM_UART_RX);
+
+    //
+    // Enable interrupts.
+    //
+    NVIC_EnableIRQ((IRQn_Type)(UART0_IRQn + AM_BSP_UART_PRINT_INST));
+    am_hal_interrupt_master_enable();
+
+    //
+    // Set the main print interface to use the UART print function we defined.
+    //
+    am_util_stdio_printf_init(uart_print);
+
+    //
+    // Print the banner.
+    //
+    am_util_stdio_terminal_clear();
+    am_util_stdio_printf("Hello World!\n\n");
+
+    //
+    // Print the device info.
+    //
+    am_util_id_device(&sIdDevice);
+    am_util_stdio_printf("Vendor Name: %s\n", sIdDevice.pui8VendorName);
+    am_util_stdio_printf("Device type: %s\n", sIdDevice.pui8DeviceName);
+
+    am_util_stdio_printf("Qualified: %s\n",
+                         sIdDevice.sMcuCtrlDevice.ui32Qualified ?
+                         "Yes" : "No");
+
+    am_util_stdio_printf("Device Info:\n"
+                         "\tPart number: 0x%08X\n"
+                         "\tChip ID0:    0x%08X\n"
+                         "\tChip ID1:    0x%08X\n"
+                         "\tRevision:    0x%08X (Rev%c%c)\n",
+                         sIdDevice.sMcuCtrlDevice.ui32ChipPN,
+                         sIdDevice.sMcuCtrlDevice.ui32ChipID0,
+                         sIdDevice.sMcuCtrlDevice.ui32ChipID1,
+                         sIdDevice.sMcuCtrlDevice.ui32ChipRev,
+                         sIdDevice.ui8ChipRevMaj, sIdDevice.ui8ChipRevMin );
+
+    //
+    // If not a multiple of 1024 bytes, append a plus sign to the KB.
+    //
+    ui32StrBuf = ( sIdDevice.sMcuCtrlDevice.ui32FlashSize % 1024 ) ? '+' : 0;
+    am_util_stdio_printf("\tFlash size:  %7d (%d KB%s)\n",
+                         sIdDevice.sMcuCtrlDevice.ui32FlashSize,
+                         sIdDevice.sMcuCtrlDevice.ui32FlashSize / 1024,
+                         &ui32StrBuf);
+
+    ui32StrBuf = ( sIdDevice.sMcuCtrlDevice.ui32SRAMSize % 1024 ) ? '+' : 0;
+    am_util_stdio_printf("\tSRAM size:   %7d (%d KB%s)\n\n",
+                         sIdDevice.sMcuCtrlDevice.ui32SRAMSize,
+                         sIdDevice.sMcuCtrlDevice.ui32SRAMSize / 1024,
+                         &ui32StrBuf);
+
+    //
+    // Print the compiler version.
+    //
+    am_hal_uart_tx_flush(phUART);
+    am_util_stdio_printf("App Compiler:    %s\n", COMPILER_VERSION);
+#ifdef AM_PART_APOLLO3
+    am_util_stdio_printf("HAL Compiler:    %s\n", g_ui8HALcompiler);
+    am_util_stdio_printf("HAL SDK version: %d.%d.%d\n",
+                         g_ui32HALversion.s.Major,
+                         g_ui32HALversion.s.Minor,
+                         g_ui32HALversion.s.Revision);
+    am_util_stdio_printf("HAL compiled with %s-style registers\n",
+                         g_ui32HALversion.s.bAMREGS ? "AM_REG" : "CMSIS");
+
+    am_hal_security_info_t secInfo;
+    char sINFO[32];
+    uint32_t ui32Status;
+    ui32Status = am_hal_security_get_info(&secInfo);
+    if (ui32Status == AM_HAL_STATUS_SUCCESS)
+    {
+        if ( secInfo.bInfo0Valid )
+        {
+            am_util_stdio_sprintf(sINFO, "INFO0 valid, ver 0x%X", secInfo.info0Version);
+        }
+        else
+        {
+            am_util_stdio_sprintf(sINFO, "INFO0 invalid");
+        }
+
+        am_util_stdio_printf("SBL ver: 0x%x - 0x%x, %s\n",
+            secInfo.sblVersion, secInfo.sblVersionAddInfo, sINFO);
+    }
+    else
+    {
+        am_util_stdio_printf("am_hal_security_get_info failed 0x%X\n", ui32Status);
+    }
+#endif // AM_PART_APOLLO3
+
+    //
+    // We are done printing.
+    // Disable the UART and interrupts
+    //
+    am_hal_uart_tx_flush(phUART);
+    CHECK_ERRORS(am_hal_uart_power_control(phUART, AM_HAL_SYSCTRL_DEEPSLEEP, false));
+
+    //
+    // Loop forever while sleeping.
+    //
+    while (1)
+    {
+        //
+        // Go to Deep Sleep.
+        //
+        am_hal_sysctrl_sleep(AM_HAL_SYSCTRL_SLEEP_DEEP);
+    }
+}

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -49,7 +49,7 @@
 //
 //*****************************************************************************
 
-#include "am_mcu_apollo.h"
+extern "C" { #include "am_mcu_apollo.h" } // extern "C" is required because Release 2.2.0 of the AmbiqSuite SDK still has some HAL headers without this CPP guard built in
 #include "am_bsp.h"
 #include "am_util.h"
 

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -57,6 +57,24 @@ extern "C" {                    // extern "C" is required because Release 2.2.0 
 
 //*****************************************************************************
 //
+// C++ Functionality demonstration
+//
+//*****************************************************************************
+class CPPPrinter {
+private:
+protected:
+public:
+    uint8_t value;
+
+    CPPPrinter( uint8_t _value ) : value(_value) {};
+
+    void printValue( void ){
+        am_util_stdio_printf("I am a CPPPrinter and my value is %d\n", value);
+    }
+};
+
+//*****************************************************************************
+//
 // UART handle.
 //
 //*****************************************************************************

--- a/common/examples/hello_world_uart_cpp/main.cpp
+++ b/common/examples/hello_world_uart_cpp/main.cpp
@@ -73,6 +73,8 @@ public:
     }
 };
 
+CPPPrinter myCPPPrinter(12);
+
 //*****************************************************************************
 //
 // UART handle.
@@ -242,6 +244,11 @@ extern "C" int main(void)
     //
     am_util_stdio_terminal_clear();
     am_util_stdio_printf("Hello World!\n\n");
+
+    //
+    // Test CPPPrinter
+    //
+    myCPPPrinter.printValue();
 
     //
     // Print the device info.

--- a/common/tools_sfe/templates/makefile_template.mk
+++ b/common/tools_sfe/templates/makefile_template.mk
@@ -261,17 +261,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/common/tools_sfe/templates/makefile_template.mk
+++ b/common/tools_sfe/templates/makefile_template.mk
@@ -315,6 +315,10 @@ directories: $(CONFIG)
 $(CONFIG):
 	@mkdir -p $@
 
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/common/tools_sfe/templates/makefile_template.mk
+++ b/common/tools_sfe/templates/makefile_template.mk
@@ -285,6 +285,11 @@ CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
 
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
 LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map

--- a/common/tools_sfe/templates/makefile_template.mk
+++ b/common/tools_sfe/templates/makefile_template.mk
@@ -319,6 +319,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/common/tools_sfe/templates/makefile_template.mk
+++ b/common/tools_sfe/templates/makefile_template.mk
@@ -231,6 +231,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -239,7 +240,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -259,18 +260,26 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)

--- a/edge/examples/blinky/gcc/Makefile
+++ b/edge/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge/examples/blinky/gcc/Makefile
+++ b/edge/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge/examples/blinky/gcc/Makefile
+++ b/edge/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge/examples/hello_world_uart/gcc/Makefile
+++ b/edge/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge/examples/hello_world_uart/gcc/Makefile
+++ b/edge/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge/examples/hello_world_uart/gcc/Makefile
+++ b/edge/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge/examples/hello_world_uart_cpp/README.txt
+++ b/edge/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/edge/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/edge/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/edge/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge/examples/hm01b0_camera_uart/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge/examples/hm01b0_camera_uart/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge/examples/hm01b0_camera_uart/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -266,17 +266,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -236,6 +236,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -244,7 +245,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -264,22 +265,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -305,6 +319,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -324,6 +324,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/blinky/gcc/Makefile
+++ b/edge2/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/blinky/gcc/Makefile
+++ b/edge2/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge2/examples/blinky/gcc/Makefile
+++ b/edge2/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge2/examples/hello_world_uart/gcc/Makefile
+++ b/edge2/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/hello_world_uart/gcc/Makefile
+++ b/edge2/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge2/examples/hello_world_uart/gcc/Makefile
+++ b/edge2/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge2/examples/hello_world_uart_cpp/README.txt
+++ b/edge2/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/edge2/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/edge2/examples/hello_world_uart_cpp/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/edge2/examples/hello_world_uart_cpp/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge2/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/edge2/examples/hello_world_uart_cpp/gcc/Makefile
@@ -182,7 +182,7 @@ INCLUDES+=
 
 # Compilation Units (Add all the .c files you need to compile)
 SRC=
-SRC+= main.c
+SRC+= main.cpp
 SRC+= startup_gcc.c
 SRC+= am_util_delay.c
 SRC+= am_util_faultisr.c
@@ -194,7 +194,7 @@ SRC+=
 VPATH=
 VPATH+= $(PROJECTPATH)/src
 VPATH+= $(SDKPATH)/utils
-VPATH+= $(COMMONPATH)/examples/hello_world_uart
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
 VPATH+= $(COMMONPATH)/tools_sfe/templates
 VPATH+=
 

--- a/edge2/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/edge2/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,374 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.c
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/edge2/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge2/examples/hm01b0_camera_uart/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge2/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge2/examples/hm01b0_camera_uart/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/hm01b0_camera_uart/gcc/Makefile
+++ b/edge2/examples/hm01b0_camera_uart/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -266,17 +266,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -236,6 +236,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -244,7 +245,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -264,22 +265,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -305,6 +319,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
+++ b/edge2/examples/lis2dh12_accelerometer_uart/gcc/Makefile
@@ -324,6 +324,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/pdm_fft/gcc/Makefile
+++ b/edge2/examples/pdm_fft/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/edge2/examples/pdm_fft/gcc/Makefile
+++ b/edge2/examples/pdm_fft/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/edge2/examples/pdm_fft/gcc/Makefile
+++ b/edge2/examples/pdm_fft/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis/examples/blinky/gcc/Makefile
+++ b/redboard_artemis/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis/examples/blinky/gcc/Makefile
+++ b/redboard_artemis/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis/examples/blinky/gcc/Makefile
+++ b/redboard_artemis/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis/examples/hello_world_uart_cpp/README.txt
+++ b/redboard_artemis/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/redboard_artemis/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/redboard_artemis/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/redboard_artemis/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis/examples/pdm_fft/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis/examples/pdm_fft/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis/examples/pdm_fft/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_atp/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_atp/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_atp/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_atp/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_atp/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_atp/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_atp/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_atp/examples/hello_world_uart_cpp/README.txt
+++ b/redboard_artemis_atp/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/redboard_artemis_atp/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/redboard_artemis_atp/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_atp/examples/pdm_fft/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_nano/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_nano/examples/blinky/gcc/Makefile
@@ -323,6 +323,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_nano/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_nano/examples/blinky/gcc/Makefile
@@ -265,17 +265,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_nano/examples/blinky/gcc/Makefile
+++ b/redboard_artemis_nano/examples/blinky/gcc/Makefile
@@ -235,6 +235,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -243,7 +244,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -263,22 +264,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -304,6 +318,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
@@ -322,6 +322,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
@@ -264,17 +264,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 

--- a/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
+++ b/redboard_artemis_nano/examples/hello_world_uart/gcc/Makefile
@@ -234,6 +234,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -242,7 +243,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -262,22 +263,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -303,6 +317,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_nano/examples/hello_world_uart_cpp/README.txt
+++ b/redboard_artemis_nano/examples/hello_world_uart_cpp/README.txt
@@ -1,0 +1,21 @@
+Name:
+=====
+ hello_world_uart_cpp
+
+
+Description:
+============
+ A simple "Hello World" example using the UART peripheral.
+
+
+Purpose:
+========
+This example prints a "Hello World" message with some device info
+over UART at 115200 baud. To see the output of this program, run AMFlash,
+and configure the console for UART. The example sleeps after it is done
+printing.
+
+
+******************************************************************************
+
+

--- a/redboard_artemis_nano/examples/hello_world_uart_cpp/gcc/Makefile
+++ b/redboard_artemis_nano/examples/hello_world_uart_cpp/gcc/Makefile
@@ -1,0 +1,378 @@
+#******************************************************************************
+#
+# Makefile - Rules for building the libraries, examples and docs.
+#
+# Copyright (c) 2019, Ambiq Micro
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# 
+# Third party software included in this distribution is subject to the
+# additional license terms as defined in the /docs/licenses directory.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# This is part of revision 2.1.0 of the AmbiqSuite Development Package.
+#
+#******************************************************************************
+
+#******************************************************************************
+#
+# This is an example makefile for SparkFun Apollo3 boards as used in the 
+#   AmbiqSuite SDK.
+#
+# Recommended usage
+#   make
+#   make bootload_svl (uses the SparkFun Variable Loader to upload code)
+#   make bootload_asb (uses the Ambiq Secure Bootlaoder to upload code)
+#   make clean
+#
+# Filepaths
+#   You can relocate this makefile easily by providing the path to the root of
+#   the AmbiqSuite SDK. If that path is not specified then this file will 
+#   assume that it is located in 
+#   <AmbiqSDKRoot>/boards/<your_board>/examples/<your_example>/gcc
+#   and use relative paths
+#
+# User Configuration
+#   You must also specify which COM_PORT to use if you want to use the 
+#   'bootlaoder' targets. 
+#     Windows example: 	COM_PORT=COM4
+#     *nix example: 	COM_PORT=/dev/usbserialxxxx
+#
+# Python vs. Executable
+#   For simplicity the upload tools are called as Python scripts by default.
+#   Make sure PYTHON is set to the appropriate command to run Python3 from the
+#   command line.
+#
+#******************************************************************************
+
+
+#******************************************************************************
+#
+# User Options
+#
+#******************************************************************************
+
+# COM_PORT is the serial port to use for uploading. For example COM#### on Windows or /dev/cu.usbserial-#### on *nix
+COM_PORT		?=
+# ASB_UPLOAD_BAUD is the baud rate setting of the Ambiq Secue Bootloader (ASB) as it is configured on the Apollo3. Defautls to 115200 if unset
+ASB_UPLOAD_BAUD	?=
+# SVL_UPLOAD_BAUD is the baud rate setting of the SparkFun Variable Loader (SVL). Defaults to 921600 if unset
+SVL_UPLOAD_BAUD	?=
+# PYTHON3 should evaluate to a call to the Python3 executable on your machine
+PYTHON3			?=
+
+# *Optionally* specify absolute paths to the SDK and the BSP
+# Make sure to use / instead of \ when on Windows
+SDKPATH			?=# Set as the path to the SDK root if not located at ../../../../..
+COMMONPATH		?=# Set as the path to the BSP common folder if not located at ../../../../common
+BOARDPATH		?=# Set as the path to the board if not located at ../../..
+PROJECTPATH		?=# Set as the path to the project if not located at ..
+
+### Project Settings
+TARGET := example
+COMPILERNAME := gcc
+PROJECT := example_gcc
+CONFIG := bin
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+ifeq ($(COM_PORT),)
+    COM_PORT=COM4
+    $(warning warning: you have not defined COM_PORT. Assuming it is COM4)
+endif
+ifeq ($(PYTHON3),)
+    PYTHON3=python3
+    $(warning warning: you have not defined PYTHON3. assuming it is accessible by 'python3')
+endif
+ifeq ($(ASB_UPLOAD_BAUD),)
+    ASB_UPLOAD_BAUD=115200
+    $(warning defaulting to 115200 baud for ASB)
+endif
+ifeq ($(SVL_UPLOAD_BAUD),)
+    SVL_UPLOAD_BAUD=921600
+    $(warning defaulting to 921600 baud for SVL)
+endif
+
+ifeq ($(SDKPATH),)
+    SDKPATH			=../../../../..
+    $(warning warning: you have not defined SDKPATH so will continue assuming that the SDK root is at $(SDKPATH))
+else
+# When the SDKPATH is given export it
+export SDKPATH
+endif
+
+ifeq ($(COMMONPATH),)
+    COMMONPATH			=../../../../common
+    $(warning warning: you have not defined COMMONPATH so will continue assuming that the COMMON root is at $(COMMONPATH))
+else
+# When the COMMONPATH is given export it
+export COMMONPATH
+endif
+
+ifeq ($(BOARDPATH),)
+    BOARDPATH			=../../..
+    $(warning warning: you have not defined BOARDPATH so will continue assuming that the BOARD root is at $(BOARDPATH))
+else
+# When the BOARDPATH is given export it
+export BOARDPATH
+endif
+
+ifeq ($(PROJECTPATH),)
+    PROJECTPATH			=..
+    $(warning warning: you have not defined PROJECTPATH so will continue assuming that the PROJECT root is at $(PROJECTPATH))
+else
+# When the PROJECTPATH is given export it
+export PROJECTPATH
+endif
+
+#******************************************************************************
+#
+# User Defines / Includes / Sources / Libraries
+#
+#******************************************************************************
+
+# Global Defines
+DEFINES=  -DPART_$(PART)
+DEFINES+= -DAM_CUSTOM_BDADDR
+DEFINES+= -DAM_PACKAGE_BGA
+DEFINES+= -DWSF_TRACE_ENABLED
+DEFINES+= -DAM_DEBUG_PRINTF
+DEFINES+= -DAM_PART_APOLLO3
+DEFINES+=
+
+# Includes (Add paths to where example header files are located)
+INCLUDES=
+INCLUDES+= -I$(PROJECTPATH)/src
+INCLUDES+= -I$(BOARDPATH)/bsp
+INCLUDES+= -I$(SDKPATH)
+INCLUDES+= -I$(SDKPATH)/utils
+INCLUDES+= -I$(SDKPATH)/devices
+INCLUDES+= -I$(SDKPATH)/mcu/apollo3
+INCLUDES+= -I$(SDKPATH)/CMSIS/AmbiqMicro/Include
+INCLUDES+= -I$(SDKPATH)/CMSIS/ARM/Include
+INCLUDES+=
+
+# Compilation Units (Add all the .c files you need to compile)
+SRC=
+SRC+= main.cpp
+SRC+= startup_gcc.c
+SRC+= am_util_delay.c
+SRC+= am_util_faultisr.c
+SRC+= am_util_id.c
+SRC+= am_util_stdio.c
+SRC+=
+
+# VPATH (Add paths to where your source files are located)
+VPATH=
+VPATH+= $(PROJECTPATH)/src
+VPATH+= $(SDKPATH)/utils
+VPATH+= $(COMMONPATH)/examples/hello_world_uart_cpp
+VPATH+= $(COMMONPATH)/tools_sfe/templates
+VPATH+=
+
+# LIBS (Precompiled libraries to include in the linker step)
+LIBS=
+LIBS+= $(BOARDPATH)/bsp/gcc/bin/libam_bsp.a
+LIBS+= $(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a
+LIBS+=
+
+
+
+#******************************************************************************
+#
+# Warning Messages
+#
+#******************************************************************************
+### Bootloader Tools
+AMBIQ_BIN2BOARD=$(PYTHON3) $(COMMONPATH)/tools_sfe/ambiq/ambiq_bin2board.py
+ARTEMIS_SVL=$(PYTHON3) $(COMMONPATH)/tools_sfe/artemis/artemis_svl.py
+
+
+SHELL:=/bin/bash
+#### Setup ####
+
+TOOLCHAIN ?= arm-none-eabi
+PART = apollo3
+CPU = cortex-m4
+FPU = fpv4-sp-d16
+# Default to FPU hardware calling convention.  However, some customers and/or
+# applications may need the software calling convention.
+#FABI = softfp
+FABI = hard
+
+STARTUP_FILE := ./startup_$(COMPILERNAME).c
+
+#### Required Executables ####
+CC = $(TOOLCHAIN)-gcc
+GCC = $(TOOLCHAIN)-gcc
+CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
+LD = $(TOOLCHAIN)-ld
+CP = $(TOOLCHAIN)-objcopy
+OD = $(TOOLCHAIN)-objdump
+RD = $(TOOLCHAIN)-readelf
+AR = $(TOOLCHAIN)-ar
+SIZE = $(TOOLCHAIN)-size
+RM = $(shell which rm 2>/dev/null)
+
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $($(exec)) 2>/dev/null),,\
+        $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
+$(if $(strip $(value K)),$(info Required Program(s) $(strip $(value K)) not found))
+
+ifneq ($(strip $(value K)),)
+all clean:
+	$(info Tools $(TOOLCHAIN)-$(COMPILERNAME) not installed.)
+	$(RM) -rf bin
+else
+
+
+
+#******************************************************************************
+#
+# Machinery
+#
+#******************************************************************************
+
+XSRC = $(filter %.cpp,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
+CSRC = $(filter %.c,$(SRC))
+ASRC = $(filter %.s,$(SRC))
+
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
+
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
+
+CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+CFLAGS+= -ffunction-sections -fdata-sections
+CFLAGS+= -MMD -MP -Wall -g
+CFLAGS+= -O0
+CFLAGS+= $(DEFINES)
+CFLAGS+= $(INCLUDES)
+CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
+
+LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
+LFLAGS+= -nostartfiles -static
+LFLAGS+= -Wl,--gc-sections,--entry,Reset_Handler,-Map,$(CONFIG)/$(TARGET).map
+LFLAGS+= -Wl,--start-group -lm -lc -lgcc $(LIBS) -Wl,--end-group
+LFLAGS+= 
+
+# Additional user specified CFLAGS
+CFLAGS+=$(EXTRA_CFLAGS)
+
+CPFLAGS = -Obinary
+
+ODFLAGS = -S
+
+#******************************************************************************
+#
+# Targets / Rules
+#
+#******************************************************************************
+all: directories $(CONFIG)/$(TARGET)_asb.bin
+
+directories: $(CONFIG)
+
+$(CONFIG):
+	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.c $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/%.o: %.s $(CONFIG)/%.d
+	@echo " Assembling $(COMPILERNAME) $<" ;\
+	$(CC) -c $(CFLAGS) $< -o $@
+
+$(CONFIG)/$(TARGET)_asb.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_linker.ld
+$(CONFIG)/$(TARGET)_asb.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_svl.axf: LINKER_FILE = $(COMMONPATH)/tools_sfe/templates/asb_svl_linker.ld
+$(CONFIG)/$(TARGET)_svl.axf: $(OBJS) $(LIBS)
+	@echo " Linking $(COMPILERNAME) $@ with script $(LINKER_FILE)";\
+	$(CC) -Wl,-T,$(LINKER_FILE) -o $@ $(OBJS) $(LFLAGS)
+
+$(CONFIG)/$(TARGET)_%.bin: $(CONFIG)/$(TARGET)_%.axf
+	@echo " Copying $(COMPILERNAME) $@..." ;\
+	$(CP) $(CPFLAGS) $< $@ ;\
+	$(OD) $(ODFLAGS) $< > $(CONFIG)/$(TARGET).lst
+
+bootload_asb: directories $(CONFIG)/$(TARGET)_asb.bin
+	$(AMBIQ_BIN2BOARD) --bin $(CONFIG)/$(TARGET)_asb.bin --load-address-blob 0x20000 --magic-num 0xCB -o $(CONFIG)/$(TARGET) --version 0x0 --load-address-wired 0xC000 -i 6 --options 0x1 -b $(ASB_UPLOAD_BAUD) -port $(COM_PORT) -r 2 -v 
+
+bootload_svl: directories $(CONFIG)/$(TARGET)_svl.bin
+	$(ARTEMIS_SVL) $(COM_PORT) -f $(CONFIG)/$(TARGET)_svl.bin -b $(SVL_UPLOAD_BAUD) -v
+
+bootload: bootload_svl
+
+clean:
+	@echo "Cleaning..." ;\
+	$(RM) -R -f $(CONFIG)
+
+$(CONFIG)/%.d: ;
+
+$(SDKPATH)/mcu/apollo3/hal/gcc/bin/libam_hal.a:
+	$(MAKE) -C $(SDKPATH)/mcu/apollo3/hal/gcc
+
+$(SDKPATH)/third_party/uecc/gcc/bin/lib_uecc.a:
+	$(MAKE) -C $(SDKPATH)/third_party/uecc
+
+$(BOARDPATH)/bsp/gcc/bin/libam_bsp.a:
+	$(MAKE) -C $(BOARDPATH)/bsp/gcc
+
+# Automatically include any generated dependencies
+-include $(DEPS)
+endif
+.PHONY: all clean directories bootload bootload_asb bootload_svl

--- a/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
@@ -237,6 +237,7 @@ STARTUP_FILE := ./startup_$(COMPILERNAME).c
 CC = $(TOOLCHAIN)-gcc
 GCC = $(TOOLCHAIN)-gcc
 CPP = $(TOOLCHAIN)-cpp
+CXX = $(TOOLCHAIN)-g++
 LD = $(TOOLCHAIN)-ld
 CP = $(TOOLCHAIN)-objcopy
 OD = $(TOOLCHAIN)-objdump
@@ -245,7 +246,7 @@ AR = $(TOOLCHAIN)-ar
 SIZE = $(TOOLCHAIN)-size
 RM = $(shell which rm 2>/dev/null)
 
-EXECUTABLES = CC LD CP OD AR RD SIZE GCC
+EXECUTABLES = CC LD CP OD AR RD SIZE GCC CXX
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $($(exec)) 2>/dev/null),,\
         $(info $(exec) not found on PATH ($($(exec))).)$(exec)))
@@ -265,22 +266,35 @@ else
 #
 #******************************************************************************
 
+XSRC = $(filter %.cpp,$(SRC))
+XSRC+= $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
-OBJS = $(CSRC:%.c=$(CONFIG)/%.o)
+OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
+OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
-DEPS = $(CSRC:%.c=$(CONFIG)/%.d)
+DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
+DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
+
+CSTD = -std=c99 
 
 CFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 CFLAGS+= -ffunction-sections -fdata-sections
-CFLAGS+= -MMD -MP -std=c99 -Wall -g
+CFLAGS+= -MMD -MP -Wall -g
 CFLAGS+= -O0
 CFLAGS+= $(DEFINES)
 CFLAGS+= $(INCLUDES)
 CFLAGS+= 
+
+XSTD   = -std=gnu++11
+
+XFLAGS = $(CFLAGS)
+XFLAGS+= -fno-exceptions
 
 LFLAGS = -mthumb -mcpu=$(CPU) -mfpu=$(FPU) -mfloat-abi=$(FABI)
 LFLAGS+= -nostartfiles -static
@@ -306,6 +320,10 @@ directories: $(CONFIG)
 
 $(CONFIG):
 	@mkdir -p $@
+
+$(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\

--- a/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
@@ -325,6 +325,10 @@ $(CONFIG)/%.o: %.cpp $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
 
+$(CONFIG)/%.o: %.cc $(CONFIG)/%.d
+	@echo " Compiling $(COMPILERNAME) $<" ;\
+	$(CXX) -c $(XSTD) $(XFLAGS) $< -o $@
+
 $(CONFIG)/%.o: %.c $(CONFIG)/%.d
 	@echo " Compiling $(COMPILERNAME) $<" ;\
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
+++ b/redboard_artemis_nano/examples/pdm_fft/gcc/Makefile
@@ -267,17 +267,17 @@ else
 #******************************************************************************
 
 XSRC = $(filter %.cpp,$(SRC))
-XSRC+= $(filter %.cc,$(SRC))
+ZSRC = $(filter %.cc,$(SRC))
 CSRC = $(filter %.c,$(SRC))
 ASRC = $(filter %.s,$(SRC))
 
 OBJS = $(XSRC:%.cpp=$(CONFIG)/%.o)
-OBJS+= $(XSRC:%.cc=$(CONFIG)/%.o)
+OBJS+= $(ZSRC:%.cc=$(CONFIG)/%.o)
 OBJS+= $(CSRC:%.c=$(CONFIG)/%.o)
 OBJS+= $(ASRC:%.s=$(CONFIG)/%.o)
 
 DEPS = $(XSRC:%.cpp=$(CONFIG)/%.d)
-DEPS+= $(XSRC:%.cc=$(CONFIG)/%.d)
+DEPS+= $(ZSRC:%.cc=$(CONFIG)/%.d)
 DEPS+= $(CSRC:%.c=$(CONFIG)/%.d)
 DEPS+= $(ASRC:%.s=$(CONFIG)/%.d)
 


### PR DESCRIPTION
This PR add initial support for C Plus Plus to the BSP repo. Inspired by @justiceamoh and #14 

The current implementation does not call constructors at startup. This is an issue that must be fixed for true CPP support.