### PR TITLE
BSP Regen Script Upgrades

### DIFF
--- a/common/bsp_pinconfig/pinconfig.py
+++ b/common/bsp_pinconfig/pinconfig.py
@@ -483,7 +483,7 @@ def write_Cfiles(pinobj, bCreateC):
         strHfile += '\n'
 
         if pin.pinnum != intnotgiven:
-            strHfile += '#define AM_BSP_GPIO_%-20s' % pin.name  +  '%d\n' % pin.pinnum
+            strHfile += '#define AM_BSP_GPIO_%-20s\t' % pin.name  +  '%d\n' % pin.pinnum
             strHfile += 'extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_%s;\n' % pin.name
             #strHfile += '\n'
 

--- a/common/bsp_pinconfig/scripts/regen_bsp_libs.sh
+++ b/common/bsp_pinconfig/scripts/regen_bsp_libs.sh
@@ -6,7 +6,7 @@
 # example usage
 # locations:
 #   from bsp repo root:
-#     ./common/bsp_pinconfig/scripts/regen_bsp_libs.sh
+#     common/bsp_pinconfig/scripts/regen_bsp_libs.sh
 #   from remote location: (requires $AMSDK environment variable -- {boards_sfe} can be whatever you named the root of the bsp repo )
 #     $AMSDK/{boards_sfe}/common/bsp_pinconfig/scripts/regen_bsp_libs.sh -r $AMSDK/{boards_sfe} 
 # arguments:

--- a/common/bsp_pinconfig/scripts/regen_bsp_libs.sh
+++ b/common/bsp_pinconfig/scripts/regen_bsp_libs.sh
@@ -1,15 +1,62 @@
 #!/usr/bin/env bash
-# run me from the repo root
 # requires:
-# - this repo existing in a directory under ${AM_SDK_ROOT}
 # - 'make' available at the command line
 # - 'arm-none-eabi-xxx' available at the command line (preferred version is q4-2018-major)
 
-DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-source $DIR/boards.sh
+# example usage
+# locations:
+#   from bsp repo root:
+#     ./common/bsp_pinconfig/scripts/regen_bsp_libs.sh
+#   from remote location: (requires $AMSDK environment variable -- {boards_sfe} can be whatever you named the root of the bsp repo )
+#     $AMSDK/{boards_sfe}/common/bsp_pinconfig/scripts/regen_bsp_libs.sh -r $AMSDK/{boards_sfe} 
+# arguments:
+#   [-r $BSP_ROOT]      path to bsp root      optional -- defaults to the current directory 
+#                                                         (should be specified when calling script remotely)
+#   [-b $BOARDS_FILE]   path to boards file   optional -- defaults to all supported bsp boards 
+#                                                         (for now boards bust still have source files located in the bsp repo)
 
+# setup
+set -e
+set -o errexit
+echo "" 1>&2
+
+# get enclosing directory
+DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+# defaults
+BSP_ROOT=.
+BOARDS_FILE=$DIR/boards.sh
+
+# handle arguments
+while getopts ":r:b:" opt; do
+  case $opt in
+    r) BSP_ROOT="$OPTARG"
+    ;;
+    b) BOARDS_FILE="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" 1>&2
+    ;;
+  esac
+done
+
+# verify bsp root
+echo "Using \$BSP_ROOT=$BSP_ROOT" 1>&2
+VFILE=$BSP_ROOT/README.md
+if [ -f "$VFILE" ]; 
+then
+    echo "\$BSP_ROOT verification passed" 1>&2
+else
+    echo "\$BSP_ROOT verification failed" 1>&2
+    exit 1
+fi
+
+# load in boards to handle
+echo "Using \$BOARDS_FILE=$BOARDS_FILE" 1>&2
+source $BOARDS_FILE
+
+echo "" 1>&2
 for value in $BOARDS
 do
-    echo "Regenerating bsp library for: $value"
-    make -C $value/bsp/gcc
+    echo "Regenerating bsp library for: $value" 1>&2
+    make -C $BSP_ROOT/$value/bsp/gcc
 done

--- a/common/bsp_pinconfig/scripts/regen_bsp_pins.sh
+++ b/common/bsp_pinconfig/scripts/regen_bsp_pins.sh
@@ -1,14 +1,63 @@
 #!/usr/bin/env bash
-# run me from the repo root
 # requires:
 # - python3 available at the command line
 
-DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-source $DIR/boards.sh
+# example usage
+# locations:
+#   from bsp repo root:
+#     ./common/bsp_pinconfig/scripts/regen_bsp_pins.sh
+#   from remote location: (requires $AMSDK environment variable -- {boards_sfe} can be whatever you named the root of the bsp repo )
+#     $AMSDK/{boards_sfe}/common/bsp_pinconfig/scripts/regen_bsp_pins.sh -r $AMSDK/{boards_sfe} 
+# arguments:
+#   [-r $BSP_ROOT]      path to bsp root      optional -- defaults to the current directory 
+#                                                         (should be specified when calling script remotely)
+#   [-b $BOARDS_FILE]   path to boards file   optional -- defaults to all supported bsp boards 
+#                                                         (for now boards bust still have source files located in the bsp repo)
 
+# setup
+set -e
+set -o errexit
+echo "" 1>&2
+
+# get enclosing directory
+DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+# defaults
+BSP_ROOT=.
+BOARDS_FILE=$DIR/boards.sh
+
+# handle arguments
+while getopts ":r:b:" opt; do
+  case $opt in
+    r) BSP_ROOT="$OPTARG"
+    ;;
+    b) BOARDS_FILE="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" 1>&2
+    ;;
+  esac
+done
+
+# verify bsp root
+echo "Using \$BSP_ROOT=$BSP_ROOT" 1>&2
+VFILE=$BSP_ROOT/README.md
+if [ -f "$VFILE" ]; 
+then
+    echo "\$BSP_ROOT verification passed" 1>&2
+else
+    echo "\$BSP_ROOT verification failed" 1>&2
+    exit 1
+fi
+
+# load in boards to handle
+echo "Using \$BOARDS_FILE=$BOARDS_FILE" 1>&2
+source $BOARDS_FILE
+
+# generate bsp files for every board
+echo "" 1>&2
 for value in $BOARDS
 do
-    echo "Regenerating bsp_pins files for: $value"
-    common/bsp_pinconfig/pinconfig.py $value/bsp/bsp_pins.src h > $value/bsp/am_bsp_pins.h
-    common/bsp_pinconfig/pinconfig.py $value/bsp/bsp_pins.src c > $value/bsp/am_bsp_pins.c
+    echo "Regenerating bsp_pins files for: $value" 1>&2
+    $BSP_ROOT/common/bsp_pinconfig/pinconfig.py $BSP_ROOT/$value/bsp/bsp_pins.src h > $BSP_ROOT/$value/bsp/am_bsp_pins.h
+    $BSP_ROOT/common/bsp_pinconfig/pinconfig.py $BSP_ROOT/$value/bsp/bsp_pins.src c > $BSP_ROOT/$value/bsp/am_bsp_pins.c
 done

--- a/common/bsp_pinconfig/scripts/regen_bsp_pins.sh
+++ b/common/bsp_pinconfig/scripts/regen_bsp_pins.sh
@@ -5,7 +5,7 @@
 # example usage
 # locations:
 #   from bsp repo root:
-#     ./common/bsp_pinconfig/scripts/regen_bsp_pins.sh
+#     common/bsp_pinconfig/scripts/regen_bsp_pins.sh
 #   from remote location: (requires $AMSDK environment variable -- {boards_sfe} can be whatever you named the root of the bsp repo )
 #     $AMSDK/{boards_sfe}/common/bsp_pinconfig/scripts/regen_bsp_pins.sh -r $AMSDK/{boards_sfe} 
 # arguments:

--- a/common/bsp_pinconfig/scripts/regen_bsps.sh
+++ b/common/bsp_pinconfig/scripts/regen_bsps.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
-# run me from the repo root
 # requires:
 # - see requirements of source scripts
 
+# example usage
+# locations:
+#   from bsp repo root:
+#     common/bsp_pinconfig/scripts/regen_bsps.sh
+#   from remote location: (requires $AMSDK environment variable -- {boards_sfe} can be whatever you named the root of the bsp repo )
+#     $AMSDK/{boards_sfe}/common/bsp_pinconfig/scripts/regen_bsps.sh -r $AMSDK/{boards_sfe} 
+# arguments:
+#   [-r $BSP_ROOT]      path to bsp root      optional -- defaults to the current directory 
+#                                                         (should be specified when calling script remotely)
+#   [-b $BOARDS_FILE]   path to boards file   optional -- defaults to all supported bsp boards 
+#                                                         (for now boards bust still have source files located in the bsp repo)
+
+# setup
+set -e
+set -o errexit
+echo "" 1>&2
+
+# get enclosing directory
 DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-source $DIR/regen_bsp_pins.sh # regenerates source (.h and .c) files from the bsp_pins.src files
-source $DIR/regen_bsp_libs.sh # regenerates library archive files from bsp source (.h and .c) files
+
+# defaults
+BSP_ROOT=.
+BOARDS_FILE=$DIR/boards.sh
+
+# handle arguments
+while getopts ":r:b:" opt; do
+  case $opt in
+    r) BSP_ROOT="$OPTARG"
+    ;;
+    b) BOARDS_FILE="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" 1>&2
+    ;;
+  esac
+done
+
+# regen pins and libs
+$BSP_ROOT/common/bsp_pinconfig/scripts/regen_bsp_pins.sh -r $BSP_ROOT -b $BOARDS_FILE # regenerates source (.h and .c) files from the bsp_pins.src files
+$BSP_ROOT/common/bsp_pinconfig/scripts/regen_bsp_libs.sh -r $BSP_ROOT -b $BOARDS_FILE # regenerates library archive files from bsp source (.h and .c) files


### PR DESCRIPTION
Allows BSP regeneration scripts to be called remotely and for alternate board sets to be processed

Also fixes a bug in the original Ambiq pinconfig.py script